### PR TITLE
Removed provider parameter from archive statement for it is no longer supported by puppet-archive

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -33,7 +33,6 @@ class oracle_java::download {
   # download archive
   if $oracle_java::format_real == 'rpm' {
     archive { "${oracle_java::install_path}/${oracle_java::filename}":
-      provider => 'curl',
       cookie   => 'oraclelicense=accept-securebackup-cookie',
       source   => $oracle_java::downloadurl,
       cleanup  => false,
@@ -42,7 +41,6 @@ class oracle_java::download {
   } else {
     # also extract and clean up if tar.gz
     archive { "${oracle_java::install_path}/${oracle_java::filename}":
-      provider     => 'curl',
       cookie       => 'oraclelicense=accept-securebackup-cookie',
       source       => $oracle_java::downloadurl,
       cleanup      => true,

--- a/manifests/installation.pp
+++ b/manifests/installation.pp
@@ -576,7 +576,6 @@ define oracle_java::installation (
 
   # download, extract and cleanup archive
   archive { "${install_path}/${filename}":
-    provider     => 'curl',
     cookie       => 'oraclelicense=accept-securebackup-cookie',
     source       => $downloadurl,
     cleanup      => true,


### PR DESCRIPTION
The new version of puppet-archive (https://forge.puppetlabs.com/puppet/archive) no longer supports the 'provider' parameter. 
