### PR TITLE
Add ensure => directory to file resource

### DIFF
--- a/manifests/install/targz.pp
+++ b/manifests/install/targz.pp
@@ -21,6 +21,7 @@ class oracle_java::install::targz {
 
   # fix permissions
   file { "${oracle_java::install_path}/${oracle_java::longversion}":
+    ensure   => directory,
     recurse  => true,
     owner    => 'root',
     group    => 'root',


### PR DESCRIPTION
Hello!
We experience strange issue with this module. On some servers we've got following error:
```
Warning: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144]: Could not back up file of type directory
Notice: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144]: Not removing directory; use 'force' to override
Warning: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144]: Could not back up file of type directory
Notice: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144]: Not removing directory; use 'force' to override
Error: Could not set 'file' on ensure: Is a directory @ rb_sysopen - /usr/java/jdk1.8.0_144 (file: /etc/puppetlabs/puppet/environments/dev/modules/oracle_java/manifests/install/targz.pp, line: 23)
Error: Could not set 'file' on ensure: Is a directory @ rb_sysopen - /usr/java/jdk1.8.0_144 (file: /etc/puppetlabs/puppet/environments/dev/modules/oracle_java/manifests/install/targz.pp, line: 23)
Wrapped exception:
Is a directory @ rb_sysopen - /usr/java/jdk1.8.0_144
Error: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144]/ensure: change from 'directory' to 'file' failed: Could not set 'file' on ensure: Is a directory @ rb_sysopen - /usr/java/jdk1.8.0_144 (file: /etc/puppetlabs/puppet/environments/dev/modules/oracle_java/manifests/install/targz.pp, line: 23)
Notice: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144/COPYRIGHT]: Dependency File[/usr/java/jdk1.8.0_144] has failures: true
Warning: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144/COPYRIGHT]: Skipping because of failed dependencies
Notice: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144/LICENSE]: Dependency File[/usr/java/jdk1.8.0_144] has failures: true
Warning: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144/LICENSE]: Skipping because of failed dependencies
Notice: /Stage[main]/Oracle_java::Install::Targz/File[/usr/java/jdk1.8.0_144/README.html]: Dependency File[/usr/java/jdk1.8.0_144] has failures: true

```
Debugging Puppetserver doesn't discover any correlation or root cause. Also the issue appearance is not stable across nodes (the module can work correctly on some nodes and doesn't for others). But we figured out that explicit indication that resource is directory fix the issue.  We tried different versions of the agent and the server but no luck. We believe that this change is harmless and can be useful for others who can encounter this issue and allow us to use upstream :)
